### PR TITLE
Update syntax and config to be valid with Terraform 0.12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ terraform init
 terraform apply -var 'key_name=terraform' -var 'public_key_path=/Users/chris/.ssh/id_rsa.pub'
 
 # use terraform variables with InSpec
-terraform output --json > test/verify/files/terraform.json
+terraform output -json > test/verify/files/terraform.json
 inspec exec test/verify -t aws://
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following example will provision a two-tier terraform architecture on AWS. I
 cd aws-terraform
 # run terraform
 terraform init
-terraform apply -var 'key_name=terraform' -var 'public_key_path=/Users/chris/.ssh/id_rsa.pub'
+terraform apply -var 'key_name=terraform' -var 'public_key_path=/Users/chris/.ssh/id_rsa.pub' -var 'private_key_path=/Users/chris/.ssh/id_rsa.pub'
 
 # use terraform variables with InSpec
 terraform output -json > test/verify/files/terraform.json

--- a/aws-terraform/README.md
+++ b/aws-terraform/README.md
@@ -80,10 +80,10 @@ cd terraform
 terraform init
 
 # run terraform to apply the changes
-terraform apply -var 'key_name=terraform' -var 'public_key_path=/Users/chris/.ssh/id_rsa.pub'
+terraform apply -var 'key_name=terraform' -var 'public_key_path=/Users/chris/.ssh/id_rsa.pub' -var 'private_key'path=/Users/chris/.ssh/id_rsa'
 
 # make terraform variables available to inspec
-terraform output --json > test/verify/files/terraform.json
+terraform output -json > test/verify/files/terraform.json
 
 # run the inspec profile to verify the setup
 inspec exec test/verify -t aws://

--- a/aws-terraform/main.tf
+++ b/aws-terraform/main.tf
@@ -110,6 +110,8 @@ resource "aws_instance" "web" {
   connection {
     # The default username for our AMI
     user = "ubuntu"
+		host = aws_instance.web.public_ip
+		private_key="${file(var.private_key_path)}"
 
     # The connection will use the local SSH agent for authentication.
   }

--- a/aws-terraform/main.tf
+++ b/aws-terraform/main.tf
@@ -2,7 +2,7 @@
 
 # Specify the provider and access details
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 # Create a VPC to launch our instances into
@@ -12,19 +12,19 @@ resource "aws_vpc" "default" {
 
 # Create an internet gateway to give our subnet access to the outside world
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 }
 
 # Grant the VPC internet access on its main route table
 resource "aws_route" "internet_access" {
-  route_table_id         = "${aws_vpc.default.main_route_table_id}"
+  route_table_id         = aws_vpc.default.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.default.id}"
+  gateway_id             = aws_internet_gateway.default.id
 }
 
 # Create a subnet to launch our instances into
 resource "aws_subnet" "default" {
-  vpc_id                  = "${aws_vpc.default.id}"
+  vpc_id                  = aws_vpc.default.id
   cidr_block              = "10.0.1.0/24"
   map_public_ip_on_launch = true
 }
@@ -33,7 +33,7 @@ resource "aws_subnet" "default" {
 resource "aws_security_group" "elb" {
   name        = "terraform_example_elb"
   description = "Used in the terraform"
-  vpc_id      = "${aws_vpc.default.id}"
+  vpc_id      = aws_vpc.default.id
 
   # HTTP access from anywhere
   ingress {
@@ -57,7 +57,7 @@ resource "aws_security_group" "elb" {
 resource "aws_security_group" "default" {
   name        = "terraform_example"
   description = "Used in the terraform"
-  vpc_id      = "${aws_vpc.default.id}"
+  vpc_id      = aws_vpc.default.id
 
   # SSH access from anywhere
   ingress {
@@ -87,9 +87,9 @@ resource "aws_security_group" "default" {
 resource "aws_elb" "web" {
   name = "terraform-example-elb"
 
-  subnets         = ["${aws_subnet.default.id}"]
-  security_groups = ["${aws_security_group.elb.id}"]
-  instances       = ["${aws_instance.web.id}"]
+  subnets         = [aws_subnet.default.id]
+  security_groups = [aws_security_group.elb.id]
+  instances       = [aws_instance.web.id]
 
   listener {
     instance_port     = 80
@@ -100,19 +100,21 @@ resource "aws_elb" "web" {
 }
 
 resource "aws_key_pair" "auth" {
-  key_name   = "${var.key_name}"
-  public_key = "${file(var.public_key_path)}"
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
 }
 
 resource "aws_instance" "web" {
   # The connection block tells our provisioner how to
   # communicate with the resource (instance)
+  # The connection block tells our provisioner how to
+  # communicate with the resource (instance)
   connection {
+    type = "ssh"
     # The default username for our AMI
-    user = "ubuntu"
-		host = aws_instance.web.public_ip
-		private_key="${file(var.private_key_path)}"
-
+    user        = "ubuntu"
+    host        = aws_instance.web.public_ip
+    private_key = file(var.private_key_path)
     # The connection will use the local SSH agent for authentication.
   }
 
@@ -120,19 +122,22 @@ resource "aws_instance" "web" {
 
   # Lookup the correct AMI based on the region
   # we specified
-  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  ami = var.aws_amis[var.aws_region]
 
   # The name of our SSH keypair we created above.
-  key_name = "${aws_key_pair.auth.id}"
+  key_name = aws_key_pair.auth.id
 
   # Our Security group to allow HTTP and SSH access
-  vpc_security_group_ids = ["${aws_security_group.default.id}"]
+  vpc_security_group_ids = [aws_security_group.default.id]
 
   # We're going to launch into the same subnet as our ELB. In a production
   # environment it's more common to have a separate private subnet for
   # backend instances.
-  subnet_id = "${aws_subnet.default.id}"
+  subnet_id = aws_subnet.default.id
 
+  # We run a remote provisioner on the instance after creating it.
+  # In this case, we just install nginx and start it. By default,
+  # this should be on port 80
   # We run a remote provisioner on the instance after creating it.
   # In this case, we just install nginx and start it. By default,
   # this should be on port 80
@@ -144,3 +149,4 @@ resource "aws_instance" "web" {
     ]
   }
 }
+

--- a/aws-terraform/outputs.tf
+++ b/aws-terraform/outputs.tf
@@ -1,11 +1,12 @@
 output "address" {
-  value = "${aws_elb.web.dns_name}"
+  value = aws_elb.web.dns_name
 }
 
 output "instance_id" {
-  value = "${aws_instance.web.id}"
+  value = aws_instance.web.id
 }
 
 output "vpc_id" {
-  value = "${aws_vpc.default.id}"
+  value = aws_vpc.default.id
 }
+

--- a/aws-terraform/variables.tf
+++ b/aws-terraform/variables.tf
@@ -8,10 +8,11 @@ connect.
 
 Example: ~/.ssh/terraform.pub
 DESCRIPTION
+
 }
 
 variable "private_key_path" {
-	description = "Path to the SSH private key used for authentication"
+  description = "Path to the SSH private key used for authentication"
 }
 
 variable "key_name" {
@@ -27,9 +28,10 @@ variable "aws_region" {
 variable "aws_amis" {
   default = {
     eu-central-1 = "ami-fa2fb595"
-    eu-west-1 = "ami-674cbc1e"
-    us-east-1 = "ami-1d4e7a66"
-    us-west-1 = "ami-969ab1f6"
-    us-west-2 = "ami-8803e0f0"
+    eu-west-1    = "ami-674cbc1e"
+    us-east-1    = "ami-1d4e7a66"
+    us-west-1    = "ami-969ab1f6"
+    us-west-2    = "ami-8803e0f0"
   }
 }
+

--- a/aws-terraform/variables.tf
+++ b/aws-terraform/variables.tf
@@ -10,6 +10,10 @@ Example: ~/.ssh/terraform.pub
 DESCRIPTION
 }
 
+variable "private_key_path" {
+	description = "Path to the SSH private key used for authentication"
+}
+
 variable "key_name" {
   description = "Desired name of AWS key pair"
 }

--- a/aws-terraform/versions.tf
+++ b/aws-terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Syntax updated with `terraform 0.12upgrade`. Added `versions.tf`.

Added variable `private_key_path` to `variables.tf` and specified host (required) and private_key in the connection block for the ec2 instance to allow for remote-exec to work as intented.

Tested with terraform 0.12.8
